### PR TITLE
Ci: PR Check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version: "1.23.8"
           cache: true
           cache-dependency-path: scalar/go.sum
 
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version: "1.23.8"
           cache: true
           cache-dependency-path: scalar/go.sum
 
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version: "1.23.8"
           cache: true
           cache-dependency-path: scalar/go.sum
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,78 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+          cache: true
+          cache-dependency-path: scalar/go.sum
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.5
+          working-directory: scalar
+          args: --timeout=10m
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+          cache: true
+          cache-dependency-path: scalar/go.sum
+
+      - name: Run Tests with Coverage
+        run: |
+          cd scalar
+          go test -v -coverprofile=coverage.out ./...
+
+      - name: Save coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: scalar-coverage
+          path: scalar/coverage.out
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+          cache: true
+          cache-dependency-path: scalar/go.sum
+
+      - name: Build
+        run: |
+          cd scalar
+          go build ./...
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.23.0
+          work-dir: scalar
+          go-package: ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -27,6 +30,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +74,8 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: read
     steps:
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,6 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.23.0
+          go-version-input: 1.23.8
           work-dir: scalar
           go-package: ./...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scalar middleware for [Fiber](https://github.com/gofiber/fiber). The middleware handles Scalar UI.
 
-**Note: Requires Go 1.23.0 and above**
+## Note: Requires Go 1.23.8 and above
 
 ### Table of Contents
 - [Signatures](#signatures)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scalar middleware for [Fiber](https://github.com/gofiber/fiber). The middleware handles Scalar UI.
 
-**Note: Requires Go 1.23.0 and above**
+**Note: Requires Go 1.23.8 and above**
 
 ### Table of Contents
 - [Signatures](#signatures)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scalar middleware for [Fiber](https://github.com/gofiber/fiber). The middleware handles Scalar UI.
 
-## Note: Requires Go 1.23.8 and above
+**Note: Requires Go 1.23.0 and above**
 
 ### Table of Contents
 - [Signatures](#signatures)

--- a/scalar/go.mod
+++ b/scalar/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.6
+	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/swag v1.16.4
 )
 
@@ -12,6 +13,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
@@ -23,6 +25,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.51.0 // indirect
@@ -32,4 +35,5 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/scalar/go.mod
+++ b/scalar/go.mod
@@ -1,6 +1,6 @@
 module github.com/yokeTH/gofiber-scalar/scalar
 
-go 1.23.0
+go 1.23.8
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.6

--- a/scalar/go.mod
+++ b/scalar/go.mod
@@ -1,6 +1,6 @@
 module github.com/yokeTH/gofiber-scalar/scalar
 
-go 1.23.8
+go 1.23.0
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.6

--- a/scalar/scalar_test.go
+++ b/scalar/scalar_test.go
@@ -1,12 +1,17 @@
 package scalar
 
 import (
-	_ "embed"
+	"fmt"
+	"html/template"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/swaggo/swag"
 )
 
@@ -36,13 +41,18 @@ var (
 	registrationOnce sync.Once
 )
 
-func TestDefault(t *testing.T) {
+func setupApp() *fiber.App {
 	app := fiber.New()
 
 	registrationOnce.Do(func() {
 		swag.Register(swag.Name, &mock{})
 	})
 
+	return app
+}
+
+func TestDefault(t *testing.T) {
+	app := setupApp()
 	app.Use(New())
 
 	tests := []struct {
@@ -64,12 +74,6 @@ func TestDefault(t *testing.T) {
 			statusCode:  200,
 			contentType: "application/json",
 		},
-		// {
-		// 	name:        "Should be returns status 200 with 'image/png' content-type",
-		// 	url:         "/swag/favicon-16x16.png",
-		// 	statusCode:  200,
-		// 	contentType: "image/png",
-		// },
 		{
 			name:       "Should return status 404",
 			url:        "/docs/notfound",
@@ -108,4 +112,341 @@ func TestDefault(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCustomBasePath(t *testing.T) {
+	app := setupApp()
+	app.Use(New(Config{
+		BasePath: "/api",
+	}))
+
+	tests := []struct {
+		name        string
+		url         string
+		statusCode  int
+		contentType string
+	}{
+		{
+			name:        "Should be returns status 200 with custom base path",
+			url:         "/api/docs",
+			statusCode:  200,
+			contentType: "text/html",
+		},
+		{
+			name:        "Should be returns status 200 for spec with custom base path",
+			url:         "/api/docs/doc.json",
+			statusCode:  200,
+			contentType: "application/json",
+		},
+		{
+			name:       "Should return status 404 for original path",
+			url:        "/docs",
+			statusCode: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+
+			if tt.contentType != "" {
+				assert.Equal(t, tt.contentType, resp.Header.Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestCustomPath(t *testing.T) {
+	app := setupApp()
+	app.Use(New(Config{
+		Path: "api-docs",
+	}))
+
+	tests := []struct {
+		name        string
+		url         string
+		statusCode  int
+		contentType string
+	}{
+		{
+			name:        "Should be returns status 200 with custom path",
+			url:         "/api-docs",
+			statusCode:  200,
+			contentType: "text/html",
+		},
+		{
+			name:        "Should be returns status 200 for spec with custom path",
+			url:         "/api-docs/doc.json",
+			statusCode:  200,
+			contentType: "application/json",
+		},
+		{
+			name:       "Should return status 404 for original path",
+			url:        "/docs",
+			statusCode: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+
+			if tt.contentType != "" {
+				assert.Equal(t, tt.contentType, resp.Header.Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestCustomTitle(t *testing.T) {
+	app := setupApp()
+	customTitle := "Custom API Documentation"
+	app.Use(New(Config{
+		Title: customTitle,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Create a buffer to store the response body
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+
+	// Check if the custom title is in the HTML
+	assert.Contains(t, buf.String(), fmt.Sprintf("<title>%s</title>", customTitle))
+}
+
+func TestCustomSpecUrl(t *testing.T) {
+	app := setupApp()
+	app.Use(New(Config{
+		RawSpecUrl: "swagger.json",
+	}))
+
+	tests := []struct {
+		name        string
+		url         string
+		statusCode  int
+		contentType string
+	}{
+		{
+			name:        "Should be returns status 200 with custom spec URL",
+			url:         "/docs/swagger.json",
+			statusCode:  200,
+			contentType: "application/json",
+		},
+		{
+			name:       "Should return status 404 for original spec URL",
+			url:        "/docs/doc.json",
+			statusCode: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+
+			if tt.contentType != "" {
+				assert.Equal(t, tt.contentType, resp.Header.Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestCustomFileContent(t *testing.T) {
+	app := setupApp()
+	customSpec := `{"openapi":"3.0.0","info":{"title":"Custom API","version":"1.0.0"}}`
+
+	app.Use(New(Config{
+		FileContentString: customSpec,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/docs/doc.json", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, customSpec, strings.TrimSpace(buf.String()))
+}
+
+func TestCacheControl(t *testing.T) {
+	tests := []struct {
+		name           string
+		cacheAge       int
+		expectedHeader string
+	}{
+		{
+			name:           "Should set Cache-Control with custom max-age",
+			cacheAge:       3600,
+			expectedHeader: "public, max-age=3600",
+		},
+		{
+			name:           "Should set Cache-Control to no-store when cache age is 0",
+			cacheAge:       0,
+			expectedHeader: "no-store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := setupApp()
+			app.Use(New(Config{
+				CacheAge: tt.cacheAge,
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode)
+			assert.Equal(t, tt.expectedHeader, resp.Header.Get("Cache-Control"))
+		})
+	}
+}
+
+func TestCustomStyle(t *testing.T) {
+	app := setupApp()
+	customStyle := "--primary-color: #ff0000; --font-size: 16px;"
+
+	app.Use(New(Config{
+		CustomStyle: template.CSS(customStyle),
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+
+	assert.Contains(t, buf.String(), customStyle)
+}
+
+func TestNextFunction(t *testing.T) {
+	app := setupApp()
+
+	app.Use(New(Config{
+		Next: func(c *fiber.Ctx) bool {
+			return true
+		},
+	}))
+
+	app.Get("/docs", func(c *fiber.Ctx) error {
+		return c.SendString("Next handler called")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Next handler called", buf.String())
+}
+
+func TestJSFallbackPath(t *testing.T) {
+	app := setupApp()
+	app.Use(New())
+
+	req := httptest.NewRequest(http.MethodGet, "/docs/js/api-reference.min.js", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+	assert.Greater(t, len(buf.String()), 0)
+}
+
+func TestCombinedConfigurations(t *testing.T) {
+	app := setupApp()
+	app.Use(New(Config{
+		BasePath:   "/api",
+		Path:       "swagger",
+		RawSpecUrl: "openapi.json",
+		CacheAge:   3600,
+	}))
+
+	tests := []struct {
+		name        string
+		url         string
+		statusCode  int
+		contentType string
+	}{
+		{
+			name:        "Should be returns status 200 with combined configurations",
+			url:         "/api/swagger",
+			statusCode:  200,
+			contentType: "text/html",
+		},
+		{
+			name:        "Should be returns status 200 for spec with combined configurations",
+			url:         "/api/swagger/openapi.json",
+			statusCode:  200,
+			contentType: "application/json",
+		},
+		{
+			name:       "Should return status 404 for original paths",
+			url:        "/docs",
+			statusCode: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+
+			if tt.contentType != "" {
+				assert.Equal(t, tt.contentType, resp.Header.Get("Content-Type"))
+			}
+
+			if tt.statusCode == 200 && tt.url == "/api/swagger" {
+				assert.Equal(t, "public, max-age=3600", resp.Header.Get("Cache-Control"))
+			}
+		})
+	}
+}
+
+func TestCorrectHtmlRendering(t *testing.T) {
+	app := setupApp()
+	app.Use(New())
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	assert.NoError(t, err)
+
+	htmlContent := buf.String()
+
+	assert.Contains(t, htmlContent, "<!doctype html>")
+	assert.Contains(t, htmlContent, "<div id=\"app\"></div>")
+	assert.Contains(t, htmlContent, "function initScalar()")
+	assert.Contains(t, htmlContent, "createApiReference('#app'")
 }


### PR DESCRIPTION
## Change
Upgrade to `v1.23.8` for security purposes to enforce the main package upgrade to v1.23.8 or later to avoid following CVE:
- GO-2025-3563: Request smuggling due to acceptance of invalid chunked data in net/http
- GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
- GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509