### PR TITLE
Feature: use offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ type Config struct {
 	CustomStyle template.CSS
 
 	// Proxy to avoid CORS issues
-	// Optional. Default: "https://proxy.scalar.com"
+	// Optional. Default: ""
 	ProxyUrl string
 
 	// Raw Space Url
@@ -141,7 +141,6 @@ var configDefault = Config{
 	Path:       "docs",
 	Title:      "Fiber API documentation",
 	CacheAge:   60,
-	ProxyUrl:   "https://proxy.scalar.com",
 	RawSpecUrl: "doc.json",
 }
 ```

--- a/scalar/config.go
+++ b/scalar/config.go
@@ -58,6 +58,5 @@ var configDefault = Config{
 	Path:       "docs",
 	Title:      "Fiber API documentation",
 	CacheAge:   60,
-	ProxyUrl:   "https://proxy.scalar.com",
 	RawSpecUrl: "doc.json",
 }

--- a/scalar/index.go
+++ b/scalar/index.go
@@ -19,26 +19,7 @@ const templateHTML = `
 
   <body>
     <div id="app"></div>
-
     <script>
-      if (!navigator.onLine) {
-        var script = document.createElement('script');
-        script.src = '{{ .Extra.FallbackUrl }}';
-        script.onload = initScalar;
-        document.head.appendChild(script);
-      } else {
-        var cdn = document.createElement('script');
-        cdn.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
-        cdn.onload = initScalar;
-        cdn.onerror = function () {
-          var fallback = document.createElement('script');
-          fallback.src = '{{ .Extra.FallbackUrl }}';
-          fallback.onload = initScalar;
-          document.head.appendChild(fallback);
-        };
-        document.head.appendChild(cdn);
-      }
-
       function initScalar() {
         if (typeof Scalar !== 'undefined') {
           Scalar.createApiReference('#app', {
@@ -47,8 +28,12 @@ const templateHTML = `
             proxyUrl: "{{.ProxyUrl}}",
             {{ end }}
           });
+        }else{
+	      console.error("Failed to load Scalar API Reference");
+	      document.querySelector('#app').innerHTML = "<p>Something went wrong. Please report this bug at <a href='https://github.com/yokeTH/gofiber-scalar/issues'>https://github.com/yokeTH/gofiber-scalar/issues</a></p>";
         }
       }
     </script>
+    <script src="{{ .Extra.FallbackUrl }}" onload="initScalar()" ></script>
   </body>
 </html>`

--- a/scalar/scalar.go
+++ b/scalar/scalar.go
@@ -31,9 +31,6 @@ func New(config ...Config) fiber.Handler {
 		if len(cfg.Title) == 0 {
 			cfg.Title = configDefault.Title
 		}
-		if len(cfg.ProxyUrl) == 0 {
-			cfg.ProxyUrl = configDefault.ProxyUrl
-		}
 		if len(cfg.RawSpecUrl) == 0 {
 			cfg.RawSpecUrl = configDefault.RawSpecUrl
 		}


### PR DESCRIPTION
Since I implemented the auto-update scalar feature, there should be an offline way to make it even faster.

## Change
- Use offline only.
- Remove the proxy URL, as it’s no longer needed.

The label “major” is required because I want to start version 1.x.x.