### PR TITLE
Update README with Fiber v3 RC information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> Fiber v3 is currently in development and in the release candidate (RC) stage. Since gofiber-scalar follows the same release cycle, it is also in RC. If you’re using Fiber v3, install it with: `go get -u github.com/yokeTH/gofiber-scalar/scalar/v3`
+
 # Gofiber Scalar
 
 Scalar middleware for [Fiber](https://github.com/gofiber/fiber). The middleware handles Scalar UI.


### PR DESCRIPTION
This pull request updates the `README.md` file to provide important information for users working with Fiber v3. It adds a note about the current development and release candidate (RC) status of Fiber v3 and instructs users on how to install the compatible version of `gofiber-scalar`.

Documentation update:

* Added a note highlighting that both Fiber v3 and `gofiber-scalar` are in the release candidate stage, and included installation instructions for users of Fiber v3.