### PR TITLE
chore: fix PR check triggers, limit dependabot to direct deps, fix docs defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - "🤖 Dependencies"
     schedule:
       interval: "daily"
+    # Indirect deps are floored by direct deps (MVS); consumers resolve their own patched versions.
+    allow:
+      - dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 15

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read
@@ -17,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25.0"
+          go-version-file: scalar/go.mod
           cache: true
           cache-dependency-path: scalar/go.sum
 
@@ -30,8 +29,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -39,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.23.0"
+          go-version-file: scalar/go.mod
           cache: true
           cache-dependency-path: scalar/go.sum
 
@@ -63,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.23.0"
+          go-version-file: scalar/go.mod
           cache: true
           cache-dependency-path: scalar/go.sum
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ type Config struct {
 
 	// Path combines with BasePath for the full UI path
 	//
-	// Optional. Default: docs
+	// Optional. Default: /docs
 	Path string
 
 	// Title for the documentation site
@@ -163,7 +163,7 @@ type Config struct {
 ```go
 var configDefault = Config{
 	BasePath:         "/",
-	Path:             "docs",
+	Path:             "/docs",
 	Title:            "Fiber API documentation",
 	CacheAge:         60,
 	Theme:            ThemeNone,

--- a/scalar/config.go
+++ b/scalar/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// Path combines with BasePath for the full UI path
 	//
-	// Optional. Default: docs
+	// Optional. Default: /docs
 	Path string
 
 	// Title for the documentation site


### PR DESCRIPTION
Library-maintenance fixes:

- **ci**: PR checks were triggered on PRs to `main`, but the default branch is `v3` — they never ran. Removed the branch filter and unified all jobs on `go-version-file: scalar/go.mod` (was a mix of 1.25.0 and 1.23.0). Also dropped an unneeded `contents: write` permission from the test job.
- **chore**: limit dependabot gomod updates to direct dependencies. Indirect deps are floored by direct deps (MVS); consumers resolve their own patched versions, so the library no longer gets bump-indirect-dep PRs.
- **docs**: the documented default `Path` was `docs`; the actual default is `/docs`.